### PR TITLE
Fix SVG height for the challenge function

### DIFF
--- a/query/function/localpackage/challenge.py
+++ b/query/function/localpackage/challenge.py
@@ -462,8 +462,9 @@ def challenge_svg(request):
                 c += 1
                 titles["I" + str(c)] = {"name": name, "class": "missing"}
     maxcol = trunc(sqrt(c))
+    maxrow = (c - 1) // maxcol + 1
     width = maxcol * 21
-    height = maxcol * 21 + 100
+    height = maxrow * 21 + 100
 
     svg_start = f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}px" height="{height}px" viewBox="0 0 {width} {height}" style="background-color: black" >'
     svg_header = """


### PR DESCRIPTION
Currently number of rows is set equally to the number of columns, which is set as rounded down `sqrt(c)`. That hides some boxes, since the "col" multiplier in `row*col >= c` equation can be greater than `sqrt(c)`. I propose to calculate that correctly.

Another way to fix that is to use `maxcol = ceil(sqrt(c))`.